### PR TITLE
feat: Check if an operator is valid, if not valid throw an error to l…

### DIFF
--- a/src/lokijs.js
+++ b/src/lokijs.js
@@ -3568,6 +3568,10 @@
       // the comparison function
       var fun = LokiOps[operator];
 
+      if (typeof fun !== 'function') {
+        throw new TypeError('"' + operator + '" is not a valid operator');
+      }
+
       // "shortcut" for collection data
       var t = this.collection.data;
       // filter data length


### PR DESCRIPTION
…et users know

Current error is: `TypeError: fun is not a function`

This is not straightforward :)